### PR TITLE
Removed „>“ on original code license note - breaks compiling:

### DIFF
--- a/Firmware/TMP006/TMP006.h
+++ b/Firmware/TMP006/TMP006.h
@@ -2,21 +2,21 @@
 //We release this code under ([Beerware license](http://en.wikipedia.org/wiki/Beerware)).
 
 //Original Code license:
-> /***************************************************
->  This is a library for the TMP006 Temp Sensor
->
->  Designed specifically to work with the Adafruit TMP006 Breakout
->  ----> https://www.adafruit.com/products/1296
->
->  These displays use I2C to communicate, 2 pins are required to
->  interface
->  Adafruit invests time and resources providing this open source code,
->  please support Adafruit and open-source hardware by purchasing
->  products from Adafruit!
->
->  Written by Limor Fried/Ladyada for Adafruit Industries.
->  BSD license, all text above must be included in any redistribution
-> ****************************************************/
+ /***************************************************
+  This is a library for the TMP006 Temp Sensor
+
+  Designed specifically to work with the Adafruit TMP006 Breakout
+  ----> https://www.adafruit.com/products/1296
+
+  These displays use I2C to communicate, 2 pins are required to
+  interface
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
+  products from Adafruit!
+
+  Written by Limor Fried/Ladyada for Adafruit Industries.
+  BSD license, all text above must be included in any redistribution
+ ****************************************************/
 
 // Constants for calculating object temperature
 #define TMP006_B0 -0.0000294

--- a/Firmware/TMP006/TMP006.ino
+++ b/Firmware/TMP006/TMP006.ino
@@ -3,21 +3,21 @@
 //We release this code under ([Beerware license](http://en.wikipedia.org/wiki/Beerware)).
 
 //Original Code license:
-> /***************************************************
->  This is a library for the TMP006 Temp Sensor
->
->  Designed specifically to work with the Adafruit TMP006 Breakout
->  ----> https://www.adafruit.com/products/1296
->
->  These displays use I2C to communicate, 2 pins are required to
->  interface
->  Adafruit invests time and resources providing this open source code,
->  please support Adafruit and open-source hardware by purchasing
->  products from Adafruit!
->
->  Written by Limor Fried/Ladyada for Adafruit Industries.
->  BSD license, all text above must be included in any redistribution
-> ****************************************************/
+ /***************************************************
+  This is a library for the TMP006 Temp Sensor
+
+  Designed specifically to work with the Adafruit TMP006 Breakout
+  ----> https://www.adafruit.com/products/1296
+
+  These displays use I2C to communicate, 2 pins are required to
+  interface
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
+  products from Adafruit!
+
+  Written by Limor Fried/Ladyada for Adafruit Industries.
+  BSD license, all text above must be included in any redistribution
+ ****************************************************/
 
 // Only things needed to configure are the sensor address and
 // samples per reading, however the defaults work fine if using


### PR DESCRIPTION
Changed original license parts in TMP006.h and TMP006.ino to fix the compiler error: expected unqualified-id before '>' token
